### PR TITLE
Add checks / tests for AFIDs coord array shape

### DIFF
--- a/afids_utils/io.py
+++ b/afids_utils/io.py
@@ -90,6 +90,17 @@ def afids_to_fcsv(
         )
         fcsv = list(reader)
 
+    # Check to make sure shape of AFIDs array matches expected template
+    if afid_coords.shape[0] != len(fcsv):
+        raise TypeError(
+            f"Expected {len(fcsv)} AFIDs, but received {afid_coords.shape[0]}."
+        )
+    if afid_coords.shape[1] != 3:
+        raise TypeError(
+            "Expected 3 spatial dimensions (x, y, z),"
+            f"but received {afid_coords.shape[1]}."
+        )
+
     # Loop over fiducials and update with fiducial spatial coordinates
     for idx, row in enumerate(fcsv):
         row["x"] = afid_coords[idx][0]

--- a/afids_utils/tests/strategies.py
+++ b/afids_utils/tests/strategies.py
@@ -12,10 +12,23 @@ def afid_coords(
     min_value: float = -50.0,
     max_value: float = 50.0,
     width: int = 16,
+    bad_range: bool = False,
+    bad_dims: bool = False,
 ) -> NDArray[np.single]:
+    # Set (in)valid dimensions for array containing AFID coords
+    num_afids, spatial_dims = 32, 3
+    if bad_range:
+        num_afids = draw(
+            st.integers(min_value=0, max_value=100).filter(lambda x: x != 32)
+        )
+    if bad_dims:
+        spatial_dims = draw(
+            st.integers(min_value=0, max_value=10).filter(lambda x: x != 3)
+        )
+
     return draw(
         arrays(
-            shape=(32, 3),
+            shape=(num_afids, spatial_dims),
             dtype=np.single,
             elements=st.floats(
                 min_value=min_value, max_value=max_value, width=width

--- a/afids_utils/tests/test_io.py
+++ b/afids_utils/tests/test_io.py
@@ -64,6 +64,30 @@ class TestAfidsToFcsv:
                 "/invalid/fcsv/path",
             )
 
+    @given(afids_coords=afid_coords(bad_range=True))
+    def test_invalid_num_afids(self, afids_coords: NDArray[np.single]) -> None:
+        out_fcsv_file = tempfile.NamedTemporaryFile(
+            mode="w", delete=False, prefix="sub-test_afids.fcsv"
+        )
+        out_fcsv_path = Path(out_fcsv_file.name)
+        with pytest.raises(TypeError) as err:
+            afids_to_fcsv(afids_coords, out_fcsv_path)
+
+        assert "AFIDs, but received" in str(err.value)
+
+    @given(afids_coords=afid_coords(bad_dims=True))
+    def test_invalid_afids_dims(
+        self, afids_coords: NDArray[np.single]
+    ) -> None:
+        out_fcsv_file = tempfile.NamedTemporaryFile(
+            mode="w", delete=False, prefix="sub-test_afids.fcsv"
+        )
+        out_fcsv_path = Path(out_fcsv_file.name)
+        with pytest.raises(TypeError) as err:
+            afids_to_fcsv(afids_coords, out_fcsv_path)
+
+        assert "Expected 3 spatial dimensions" in str(err.value)
+
     @given(afids_coords=afid_coords())
     @settings(
         suppress_health_check=[HealthCheck.function_scoped_fixture],

--- a/afids_utils/tests/test_io.py
+++ b/afids_utils/tests/test_io.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import csv
 import tempfile
-from os import PathLike, remove
+from os import PathLike
 from pathlib import Path
 
 import numpy as np
@@ -66,27 +66,25 @@ class TestAfidsToFcsv:
 
     @given(afids_coords=afid_coords(bad_range=True))
     def test_invalid_num_afids(self, afids_coords: NDArray[np.single]) -> None:
-        out_fcsv_file = tempfile.NamedTemporaryFile(
-            mode="w", delete=False, prefix="sub-test_afids.fcsv"
-        )
-        out_fcsv_path = Path(out_fcsv_file.name)
-        with pytest.raises(TypeError) as err:
-            afids_to_fcsv(afids_coords, out_fcsv_path)
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
+        ) as out_fcsv_file:
+            with pytest.raises(TypeError) as err:
+                afids_to_fcsv(afids_coords, out_fcsv_file)
 
-        assert "AFIDs, but received" in str(err.value)
+            assert "AFIDs, but received" in str(err.value)
 
     @given(afids_coords=afid_coords(bad_dims=True))
     def test_invalid_afids_dims(
         self, afids_coords: NDArray[np.single]
     ) -> None:
-        out_fcsv_file = tempfile.NamedTemporaryFile(
-            mode="w", delete=False, prefix="sub-test_afids.fcsv"
-        )
-        out_fcsv_path = Path(out_fcsv_file.name)
-        with pytest.raises(TypeError) as err:
-            afids_to_fcsv(afids_coords, out_fcsv_path)
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
+        ) as out_fcsv_file:
+            with pytest.raises(TypeError) as err:
+                afids_to_fcsv(afids_coords, out_fcsv_file)
 
-        assert "Expected 3 spatial dimensions" in str(err.value)
+            assert "Expected 3 spatial dimensions" in str(err.value)
 
     @given(afids_coords=afid_coords())
     @settings(
@@ -95,40 +93,33 @@ class TestAfidsToFcsv:
     def test_write_fcsv(
         self, afids_coords: NDArray[np.single], valid_fcsv_file: PathLike[str]
     ) -> None:
-        out_fcsv_file = tempfile.NamedTemporaryFile(
-            mode="w", delete=False, prefix="sub-test_afids.fcsv"
-        )
-        out_fcsv_path = Path(out_fcsv_file.name)
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
+        ) as out_fcsv_file:
+            # Create and check output file
+            afids_to_fcsv(afids_coords, out_fcsv_file.name)
 
-        afids_to_fcsv(afids_coords, out_fcsv_path)
+            # Load files
+            with open(
+                valid_fcsv_file, "r", encoding="utf-8", newline=""
+            ) as template_fcsv_file, open(
+                out_fcsv_file.name, "r", encoding="utf-8", newline=""
+            ) as output_fcsv_file:
+                template_header = [
+                    template_fcsv_file.readline() for _ in range(3)
+                ]
+                output_header = [output_fcsv_file.readline() for _ in range(3)]
+                reader = csv.DictReader(
+                    output_fcsv_file, fieldnames=FCSV_FIELDNAMES
+                )
+                output_fcsv = list(reader)
 
-        # Check file was created
-        assert out_fcsv_path.exists()
-
-        # Load files
-        with open(
-            valid_fcsv_file, "r", encoding="utf-8", newline=""
-        ) as template_fcsv_file:
-            template_header = [template_fcsv_file.readline() for _ in range(3)]
-
-        with open(
-            out_fcsv_path, "r", encoding="utf-8", newline=""
-        ) as output_fcsv_file:
-            output_header = [output_fcsv_file.readline() for _ in range(3)]
-            reader = csv.DictReader(
-                output_fcsv_file, fieldnames=FCSV_FIELDNAMES
-            )
-            output_fcsv = list(reader)
-
-        # Check header
-        assert output_header == template_header
-        # Check contents
-        for idx, row in enumerate(output_fcsv):
-            assert (row["x"], row["y"], row["z"]) == (
-                str(afids_coords[idx][0]),
-                str(afids_coords[idx][1]),
-                str(afids_coords[idx][2]),
-            )
-
-        # Delete temporary file
-        remove(out_fcsv_path)
+            # Check header
+            assert output_header == template_header
+            # Check contents
+            for idx, row in enumerate(output_fcsv):
+                assert (row["x"], row["y"], row["z"]) == (
+                    str(afids_coords[idx][0]),
+                    str(afids_coords[idx][1]),
+                    str(afids_coords[idx][2]),
+                )


### PR DESCRIPTION
**Proposed changes**
Check to make sure the number of afids (`shape[0]`) and the spatial dimensions (`shape[1]`) match what is expected from the template. This isn't strictly necessary with current code-base, but looking to future proof it if we add other species or subsets of fiducials.

Additionally adds tests to check for the invalid cases by drawing from invalid integers and asserting a substring of the error message is raised.

Closes #9.

_Note: The actions checks will always fail due to failed build of the docs (which have not yet been merged and are not part of this PR)_

**Types of changes**
What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (if none of the other choices apply)

**Checklist**
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

**Notes**
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
