### PR TITLE
Add docstrings to Classes

### DIFF
--- a/afids_utils/afids.py
+++ b/afids_utils/afids.py
@@ -11,9 +11,27 @@ import attrs
 from afids_utils.exceptions import InvalidFiducialError, InvalidFileError
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class AfidPosition:
-    """Base class for a single AFID position"""
+    """Base class for a single AFID position
+
+    Parameters
+    ----------
+    label
+        Unique label for AFID
+
+    x
+        Spatial position along x-axis (in mm)
+
+    y
+        Spatial position along y-axis (in mm)
+
+    z
+        Spatial position along z-axis (in mm)
+
+    desc
+        Description for AFID (e.g. AC, PC)
+    """
 
     label: int = attrs.field()
     x: float = attrs.field()
@@ -22,9 +40,21 @@ class AfidPosition:
     desc: str = attrs.field()
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class AfidSet:
-    """Base class for a set of AFIDs"""
+    """Base class for a set of AFIDs
+
+    Parameters
+    ----------
+    slicer_version
+        Version of Slicer associated with AfidSet
+
+    coord_system
+        Coordinate system AFIDs are placed in (e.g. RAS)
+
+    afids
+        List of AFID labels and their coordinates
+    """
 
     slicer_version: str = attrs.field()
     coord_system: str = attrs.field()

--- a/afids_utils/exceptions.py
+++ b/afids_utils/exceptions.py
@@ -1,4 +1,4 @@
-"""Custom exceptions"""
+"""Custom exceptions to raise for various errors"""
 
 
 class InvalidFileError(Exception):
@@ -11,5 +11,5 @@ class InvalidFileError(Exception):
 class InvalidFiducialError(Exception):
     """Exception for invalid fiducial selection"""
 
-    def __init__(self, message) -> None:
+    def __init__(self, message):
         super().__init__(message)

--- a/docs/api/afids.md
+++ b/docs/api/afids.md
@@ -1,9 +1,14 @@
 ## afids_utils.afids
 
 ```{eval-rst}
-    .. autoclass: afids_utils.afids.AfidPosition
+    .. autoclass:: afids_utils.afids.AfidPosition
         :members:
+        :exclude-members: label, desc, x, y, z
 
+```
+
+```{eval-rst}
     .. autoclass:: afids_utils.afids.AfidSet
         :members:
+        :exclude-members: slicer_version, coord_system, afids
 ```

--- a/docs/exceptions/exceptions.md
+++ b/docs/exceptions/exceptions.md
@@ -1,9 +1,6 @@
 ## afids_utils.exceptions
 
 ```{eval-rst}
-    .. autoclass: afids_utils.exceptions.InvalidFileError
-        :members:
-
-    .. autoclass:: afids_utils.exceptions.InvalidFiducialError
+    .. automodule:: afids_utils.exceptions
         :members:
 ```


### PR DESCRIPTION
**Proposed changes**
Adds in missing docstrings to existing classes and updates the exceptions to use `automodule` instead of `autoclass`

At the moment, this adds some additional labour of excluding the attributes so it doesn't repeat under parameters.

**Types of changes**
What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (if none of the other choices apply)

**Checklist**
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

**Notes**
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
