### PR TITLE
Handling / saving correct coordinate system

### DIFF
--- a/afids_utils/afids.py
+++ b/afids_utils/afids.py
@@ -99,7 +99,6 @@ class AfidSet:
             afids=afids_positions,
         )
 
-    # TODO: Handle the metadata - specifically setting the coordinate system
     def save(self, out_fpath: PathLike[str] | str) -> None:
         """Save AFIDs to Slicer-compatible file
 
@@ -116,11 +115,19 @@ class AfidSet:
 
         out_fpath_ext = Path(out_fpath).suffix
 
+        # Update coordinate system for template
+        if self.coord_system not in ["LPS", "RAS", "0", "1"]:
+            raise ValueError("AfidSet contains an invalid coordinate system")
+        elif self.coord_system == "LPS":
+            self.coord_system = "0"
+        elif self.coord_system == "RAS":
+            self.coord_system = "1"
+
         # Saving fcsv
         if out_fpath_ext == ".fcsv":
             from afids_utils.ext.fcsv import save_fcsv
 
-            save_fcsv(self.afids, out_fpath)
+            save_fcsv(self, out_fpath)
         # Saving json
         # if out_fpath_ext = ".json":
         #   save_json(afids_coords, out_fpath)

--- a/afids_utils/afids.py
+++ b/afids_utils/afids.py
@@ -19,7 +19,7 @@ class AfidPosition:
     x: float = attrs.field()
     y: float = attrs.field()
     z: float = attrs.field()
-    desc: str = attrs.field()
+    desc: str = attrs.field(default="")
 
 
 @attrs.define

--- a/afids_utils/ext/fcsv.py
+++ b/afids_utils/ext/fcsv.py
@@ -6,7 +6,7 @@ import re
 from importlib import resources
 from os import PathLike
 
-from afids_utils.afids import AfidPosition
+from afids_utils.afids import AfidPosition, AfidSet
 from afids_utils.exceptions import InvalidFileError
 
 HEADER_ROWS: int = 2
@@ -140,7 +140,7 @@ def load_fcsv(
 
 
 def save_fcsv(
-    afid_coords: list[AfidPosition],
+    afid_set: AfidSet,
     out_fcsv: PathLike[str] | str,
 ) -> None:
     """
@@ -148,8 +148,8 @@ def save_fcsv(
 
     Parameters
     ----------
-    afid_coords
-        List of AFID spatial positions
+    afid_set
+        A complete AfidSet containing metadata and positions of AFIDs
 
     out_fcsv
         Path of fcsv file to save AFIDs to
@@ -170,16 +170,19 @@ def save_fcsv(
         fcsv = list(reader)
 
     # Check to make sure shape of AFIDs array matches expected template
-    if len(afid_coords) != len(fcsv):
+    if len(afid_set.afids) != len(fcsv):
         raise TypeError(
-            f"Expected {len(fcsv)} AFIDs, but received {len(afid_coords)}"
+            f"Expected {len(fcsv)} AFIDs, but received {len(afid_set.afids)}"
         )
+
+    # Update header coordinate system
+    header[1] = f"# CoordinateSystem = {afid_set.coord_system}\n"
 
     # Loop over fiducials and update with fiducial spatial coordinates
     for idx, row in enumerate(fcsv):
-        row["x"] = afid_coords[idx].x
-        row["y"] = afid_coords[idx].y
-        row["z"] = afid_coords[idx].z
+        row["x"] = afid_set.afids[idx].x
+        row["y"] = afid_set.afids[idx].y
+        row["z"] = afid_set.afids[idx].z
 
     # Write output fcsv
     with open(out_fcsv, "w", encoding="utf-8", newline="") as out_fcsv_file:

--- a/afids_utils/tests/strategies.py
+++ b/afids_utils/tests/strategies.py
@@ -5,18 +5,22 @@ from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from numpy.typing import NDArray
 
-from afids_utils.afids import AfidPosition
+from afids_utils.afids import AfidPosition, AfidSet
 
 
 @st.composite
-def afid_coords(
+def afid_set(
     draw: st.DrawFn,
     min_value: float = -50.0,
     max_value: float = 50.0,
     width: int = 16,
     bad_range: bool = False,
 ) -> list[AfidPosition]:
-    # Set (in)valid number of Afid coordinates for array containing AFID coords
+    slicer_version = draw(st.from_regex(r"\d+\.\d+"))
+    coord_system = draw(st.sampled_from(["LPS", "RAS", "0", "1"]))
+
+    # Set (in)valid number of Afid coordinates in a list
+    afid_pos = []
     num_afids = (
         32
         if not bad_range
@@ -24,8 +28,6 @@ def afid_coords(
             st.integers(min_value=0, max_value=100).filter(lambda x: x != 32)
         )
     )
-
-    afid_pos = []
     for afid in range(num_afids):
         afid_pos.append(
             AfidPosition(
@@ -49,7 +51,14 @@ def afid_coords(
             )
         )
 
-    return afid_pos
+    # Create AfidSet
+    st_afid_set = AfidSet(
+        slicer_version=slicer_version,
+        coord_system=coord_system,
+        afids=afid_pos,
+    )
+
+    return st_afid_set
 
 
 @st.composite

--- a/afids_utils/tests/strategies.py
+++ b/afids_utils/tests/strategies.py
@@ -15,6 +15,7 @@ def afid_set(
     max_value: float = 50.0,
     width: int = 16,
     bad_range: bool = False,
+    randomize_coord: bool = True,
 ) -> list[AfidPosition]:
     slicer_version = draw(st.from_regex(r"\d+\.\d+"))
     coord_system = draw(st.sampled_from(["LPS", "RAS", "0", "1"]))
@@ -54,7 +55,7 @@ def afid_set(
     # Create AfidSet
     st_afid_set = AfidSet(
         slicer_version=slicer_version,
-        coord_system=coord_system,
+        coord_system=coord_system if randomize_coord else "0",
         afids=afid_pos,
     )
 

--- a/afids_utils/tests/test_ext.py
+++ b/afids_utils/tests/test_ext.py
@@ -10,7 +10,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
-from afids_utils.afids import AfidPosition
+from afids_utils.afids import AfidPosition, AfidSet
 from afids_utils.exceptions import InvalidFileError
 from afids_utils.ext.fcsv import (
     FCSV_FIELDNAMES,
@@ -18,7 +18,7 @@ from afids_utils.ext.fcsv import (
     _get_metadata,
     save_fcsv,
 )
-from afids_utils.tests.strategies import afid_coords
+from afids_utils.tests.strategies import afid_set
 
 
 @pytest.fixture
@@ -164,32 +164,29 @@ class TestLoadFcsv:
 
 
 class TestSaveFcsv:
-    @given(afids_coords=afid_coords())
+    @given(afids_set=afid_set())
     @settings(
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_save_fcsv_invalid_template(
         self,
-        afids_coords: list[AfidPosition],
-        valid_fcsv_file: PathLike[str],
+        afids_set: AfidSet,
     ):
         with pytest.raises(FileNotFoundError):
-            save_fcsv(afids_coords, "/invalid/template/path.fcsv")
+            save_fcsv(afids_set.afids, "/invalid/template/path.fcsv")
 
-    @given(afids_coords=afid_coords())
+    @given(afids_set=afid_set())
     @settings(
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_save_fcsv_valid_template(
-        self,
-        afids_coords: list[AfidPosition],
-        valid_fcsv_file: PathLike[str],
+        self, afids_set: list[AfidPosition], valid_fcsv_file: PathLike[str]
     ):
         with tempfile.NamedTemporaryFile(
             mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
         ) as out_fcsv_file:
             # Create and check output file
-            save_fcsv(afids_coords, out_fcsv_file.name)
+            save_fcsv(afids_set.afids, out_fcsv_file.name)
 
             # Load files
             with open(
@@ -211,17 +208,21 @@ class TestSaveFcsv:
             # Check contents
             for idx, row in enumerate(output_fcsv):
                 assert (row["x"], row["y"], row["z"]) == (
-                    str(afids_coords[idx].x),
-                    str(afids_coords[idx].y),
-                    str(afids_coords[idx].z),
+                    str(afids_set.afids[idx].x),
+                    str(afids_set.afids[idx].y),
+                    str(afids_set.afids[idx].z),
                 )
 
-    @given(afids_coords=afid_coords(bad_range=True))
-    def test_invalid_num_afids(self, afids_coords: list[AfidPosition]) -> None:
+            # Check to see if file can be loaded with afids-utils
+            test_load = AfidSet.load(out_fcsv_file.name)
+            assert isinstance(test_load, AfidSet)
+
+    @given(afids_set=afid_set(bad_range=True))
+    def test_invalid_num_afids(self, afids_set: list[AfidPosition]) -> None:
         with tempfile.NamedTemporaryFile(
             mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
         ) as out_fcsv_file:
             with pytest.raises(TypeError) as err:
-                save_fcsv(afids_coords, out_fcsv_file)
+                save_fcsv(afids_set.afids, out_fcsv_file)
 
             assert "AFIDs, but received" in str(err.value)

--- a/afids_utils/tests/test_ext.py
+++ b/afids_utils/tests/test_ext.py
@@ -173,20 +173,20 @@ class TestSaveFcsv:
         afids_set: AfidSet,
     ):
         with pytest.raises(FileNotFoundError):
-            save_fcsv(afids_set.afids, "/invalid/template/path.fcsv")
+            save_fcsv(afids_set, "/invalid/template/path.fcsv")
 
-    @given(afids_set=afid_set())
+    @given(afids_set=afid_set(randomize_coord=False))
     @settings(
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_save_fcsv_valid_template(
-        self, afids_set: list[AfidPosition], valid_fcsv_file: PathLike[str]
+        self, afids_set: AfidSet, valid_fcsv_file: PathLike[str]
     ):
         with tempfile.NamedTemporaryFile(
             mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
         ) as out_fcsv_file:
             # Create and check output file
-            save_fcsv(afids_set.afids, out_fcsv_file.name)
+            save_fcsv(afids_set, out_fcsv_file.name)
 
             # Load files
             with open(
@@ -218,11 +218,11 @@ class TestSaveFcsv:
             assert isinstance(test_load, AfidSet)
 
     @given(afids_set=afid_set(bad_range=True))
-    def test_invalid_num_afids(self, afids_set: list[AfidPosition]) -> None:
+    def test_invalid_num_afids(self, afids_set: AfidSet) -> None:
         with tempfile.NamedTemporaryFile(
             mode="w", prefix="sub-test_desc-", suffix="_afids.fcsv"
         ) as out_fcsv_file:
             with pytest.raises(TypeError) as err:
-                save_fcsv(afids_set.afids, out_fcsv_file)
+                save_fcsv(afids_set, out_fcsv_file.name)
 
             assert "AFIDs, but received" in str(err.value)


### PR DESCRIPTION
**Proposed changes**
The current code base always assumes `LPS` (`0`) coordinate system when saving an `AfidSet`. This PR updates this such that the coordinate system is updated accordingly prior to saving in the legacy Slicer format (`0` or `1`). 

Also updates the `save_fcsv` to take an `AfidSet` as an input parameter instead of `list[AfidPosition]`.

_This was based off of the branch used in #24_

**Types of changes**
What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

**Checklist**
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [ ] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

**Notes**
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
