### PR TITLE
Convert between LPS/RAS coordinate systems

### DIFF
--- a/afids_utils/afids.py
+++ b/afids_utils/afids.py
@@ -85,7 +85,25 @@ def _validate_afids(
 
 @attrs.define
 class AfidVoxel:
-    """Class for Afid voxel position"""
+    """Class for Afid voxel position
+
+    Parameters
+    ----------
+    label
+        Unique label for AFID
+
+    i
+        Spatial position along i-axis
+
+    j
+        Spatial position along j-axis
+
+    k
+        Spatial position along k-axis
+
+    desc
+        Description for AFID (e.g. AC, PC)
+    """
 
     label: int = attrs.field()
     i: int = attrs.field()

--- a/afids_utils/tests/test_afids.py
+++ b/afids_utils/tests/test_afids.py
@@ -164,7 +164,6 @@ class TestAfidsIO:
     )
     def test_valid_load(
         self,
-        human_mappings: list[dict[str, str]],
         valid_fcsv_file: PathLike[str],
         label: int,
     ):

--- a/afids_utils/tests/test_transforms.py
+++ b/afids_utils/tests/test_transforms.py
@@ -110,7 +110,7 @@ class TestAfidRoundTripConvert:
         assert afid_voxel_approx.k == pytest.approx(afid_voxel.k, abs=2)
 
 
-class TestCoordSystemXfm:
+class TestXfmCoordSystem:
     @given(afid_set=af_st.afid_sets())
     @settings(
         deadline=400,
@@ -120,7 +120,7 @@ class TestCoordSystemXfm:
         with pytest.raises(
             ValueError, match=r"Unrecognized coordinate system.*"
         ):
-            af_xfm.coord_system_xfm(afid_set, new_coord_system="invalid")
+            af_xfm.xfm_coord_system(afid_set, new_coord_system="invalid")
 
     @given(afid_set=af_st.afid_sets(randomize_header=False))
     @settings(
@@ -128,8 +128,9 @@ class TestCoordSystemXfm:
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_same_coord_system(self, afid_set: AfidSet):
-        with pytest.raises(ValueError, match=r"Already saved in.*"):
-            af_xfm.coord_system_xfm(afid_set, new_coord_system="LPS")
+        assert afid_set == af_xfm.xfm_coord_system(
+            afid_set, new_coord_system="LPS"
+        )
 
     @given(afid_set=af_st.afid_sets(randomize_header=False))
     @settings(
@@ -137,18 +138,18 @@ class TestCoordSystemXfm:
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     def test_valid_new_coord_system(self, afid_set):
-        new_afid_set = af_xfm.coord_system_xfm(afid_set)
+        new_afid_set = af_xfm.xfm_coord_system(afid_set)
 
         assert isinstance(new_afid_set, AfidSet)
         assert new_afid_set.coord_system == "RAS"
 
-        for idx in range(len(new_afid_set.afids)):
+        for old_afid, new_afid in zip(afid_set.afids, new_afid_set.afids):
             assert (
-                new_afid_set.afids[idx].x,
-                new_afid_set.afids[idx].y,
-                new_afid_set.afids[idx].z,
+                new_afid.x,
+                new_afid.y,
+                new_afid.z,
             ) == (
-                -afid_set.afids[idx].x,
-                -afid_set.afids[idx].y,
-                afid_set.afids[idx].z,
+                -old_afid.x,
+                -old_afid.y,
+                old_afid.z,
             )

--- a/afids_utils/tests/test_transforms.py
+++ b/afids_utils/tests/test_transforms.py
@@ -6,8 +6,8 @@ from hypothesis import HealthCheck, given, settings
 from numpy.typing import NDArray
 
 import afids_utils.tests.strategies as af_st
-from afids_utils.afids import AfidPosition, AfidVoxel
-from afids_utils.transforms import voxel_to_world, world_to_voxel
+import afids_utils.transforms as af_xfm
+from afids_utils.afids import AfidPosition, AfidSet, AfidVoxel
 
 
 class TestAfidWorld2Voxel:
@@ -21,7 +21,7 @@ class TestAfidWorld2Voxel:
     def test_world_to_voxel_xfm(
         self, afid_position: AfidPosition, nii_affine: NDArray[np.float_]
     ):
-        afid_voxel = world_to_voxel(afid_position, nii_affine)
+        afid_voxel = af_xfm.world_to_voxel(afid_position, nii_affine)
 
         assert isinstance(afid_voxel, AfidVoxel)
         # Have to assert specific int dtype
@@ -38,7 +38,7 @@ class TestAfidWorld2Voxel:
         self, afid_voxel: AfidVoxel, nii_affine: NDArray[np.float_]
     ):
         with pytest.raises(TypeError, match="Not an AfidPosition.*"):
-            world_to_voxel(afid_voxel, nii_affine)
+            af_xfm.world_to_voxel(afid_voxel, nii_affine)
 
 
 class TestAfidVoxel2World:
@@ -50,7 +50,7 @@ class TestAfidVoxel2World:
     def test_voxel_to_world_xfm(
         self, afid_voxel: AfidVoxel, nii_affine: NDArray[np.float_]
     ):
-        afid_position = voxel_to_world(afid_voxel, nii_affine)
+        afid_position = af_xfm.voxel_to_world(afid_voxel, nii_affine)
 
         assert isinstance(afid_position, AfidPosition)
         # Have to assert specific float dtype
@@ -69,7 +69,7 @@ class TestAfidVoxel2World:
         self, afid_position: AfidPosition, nii_affine: NDArray[np.float_]
     ):
         with pytest.raises(TypeError, match="Not an AfidVoxel.*"):
-            voxel_to_world(afid_position, nii_affine)
+            af_xfm.voxel_to_world(afid_position, nii_affine)
 
 
 class TestAfidRoundTripConvert:
@@ -83,8 +83,8 @@ class TestAfidRoundTripConvert:
     def test_round_trip_world(
         self, afid_position: AfidPosition, nii_affine: NDArray[np.float_]
     ):
-        afid_voxel = world_to_voxel(afid_position, nii_affine)
-        afid_position_approx = voxel_to_world(afid_voxel, nii_affine)
+        afid_voxel = af_xfm.world_to_voxel(afid_position, nii_affine)
+        afid_position_approx = af_xfm.voxel_to_world(afid_voxel, nii_affine)
         print(afid_position, afid_position_approx, nii_affine)
 
         # Check to see if round-trip approximates to within 10mm
@@ -101,10 +101,54 @@ class TestAfidRoundTripConvert:
     def test_round_trip_voxel(
         self, afid_voxel: AfidVoxel, nii_affine: NDArray[np.float_]
     ):
-        afid_world = voxel_to_world(afid_voxel, nii_affine)
-        afid_voxel_approx = world_to_voxel(afid_world, nii_affine)
+        afid_world = af_xfm.voxel_to_world(afid_voxel, nii_affine)
+        afid_voxel_approx = af_xfm.world_to_voxel(afid_world, nii_affine)
 
         # Check to see if round-trip approximates to within 2 voxels
         assert afid_voxel_approx.i == pytest.approx(afid_voxel.i, abs=2)
         assert afid_voxel_approx.j == pytest.approx(afid_voxel.j, abs=2)
         assert afid_voxel_approx.k == pytest.approx(afid_voxel.k, abs=2)
+
+
+class TestCoordSystemXfm:
+    @given(afid_set=af_st.afid_sets())
+    @settings(
+        deadline=400,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_invalid_new_coord_system(self, afid_set: AfidSet):
+        with pytest.raises(
+            ValueError, match=r"Unrecognized coordinate system.*"
+        ):
+            af_xfm.coord_system_xfm(afid_set, new_coord_system="invalid")
+
+    @given(afid_set=af_st.afid_sets(randomize_header=False))
+    @settings(
+        deadline=400,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_same_coord_system(self, afid_set: AfidSet):
+        with pytest.raises(ValueError, match=r"Already saved in.*"):
+            af_xfm.coord_system_xfm(afid_set, new_coord_system="LPS")
+
+    @given(afid_set=af_st.afid_sets(randomize_header=False))
+    @settings(
+        deadline=400,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_valid_new_coord_system(self, afid_set):
+        new_afid_set = af_xfm.coord_system_xfm(afid_set)
+
+        assert isinstance(new_afid_set, AfidSet)
+        assert new_afid_set.coord_system == "RAS"
+
+        for idx in range(len(new_afid_set.afids)):
+            assert (
+                new_afid_set.afids[idx].x,
+                new_afid_set.afids[idx].y,
+                new_afid_set.afids[idx].z,
+            ) == (
+                -afid_set.afids[idx].x,
+                -afid_set.afids[idx].y,
+                afid_set.afids[idx].z,
+            )

--- a/afids_utils/transforms.py
+++ b/afids_utils/transforms.py
@@ -99,7 +99,7 @@ def xfm_coord_system(
     afid_set
         Object containing valid AfidSet
 
-    new_coord_sys
+    new_coord_system
         Convert AFID set to defined coordinate system (default: 'RAS')
 
     Returns

--- a/afids_utils/transforms.py
+++ b/afids_utils/transforms.py
@@ -1,8 +1,7 @@
 """Methods for transforming between different coordinate systems"""
 from __future__ import annotations
 
-from copy import deepcopy
-
+import attrs
 import numpy as np
 from numpy.typing import NDArray
 
@@ -90,7 +89,7 @@ def voxel_to_world(
     )
 
 
-def coord_system_xfm(
+def xfm_coord_system(
     afid_set: AfidSet, new_coord_system: str = "RAS"
 ) -> AfidSet:
     """Convert AFID set between LPS and RAS coordinates
@@ -111,8 +110,7 @@ def coord_system_xfm(
     Raises
     ------
     ValueError
-        If invalid coordinate system, or if already in defined
-        cordinate system
+        If invalid coordinate system
     """
     if new_coord_system not in ["RAS", "LPS"]:
         raise ValueError(
@@ -120,15 +118,12 @@ def coord_system_xfm(
         )
 
     if afid_set.coord_system == new_coord_system:
-        raise ValueError(f"Already saved in {new_coord_system}")
+        return afid_set
 
-    # Create copy and update coordinate system
-    new_afid_set = deepcopy(afid_set)
-    new_afid_set.coord_system = new_coord_system
-
-    # Update afid positions
-    for idx in range(len(new_afid_set.afids)):
-        new_afid_set.afids[idx].x = -new_afid_set.afids[idx].x
-        new_afid_set.afids[idx].y = -new_afid_set.afids[idx].y
-
-    return new_afid_set
+    # Create copy and update AFIDs for new coordinate system
+    new_afids = [
+        attrs.evolve(afid, x=-afid.x, y=-afid.y) for afid in afid_set.afids
+    ]
+    return attrs.evolve(
+        afid_set, coord_system=new_coord_system, afids=new_afids
+    )

--- a/docs/api/afids.md
+++ b/docs/api/afids.md
@@ -4,7 +4,12 @@
     .. autoclass:: afids_utils.afids.AfidPosition
         :members:
         :exclude-members: label, desc, x, y, z
+```
 
+```{eval-rst}
+    .. autoclass:: afids_utils.afids.AfidVoxel
+        :members:
+        :exclude-members: label, desc, i, j, k
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
**Proposed changes**
Adds a method that takes in one AfidSet in either "LPS" or "RAS" coordinate system and returns a new AfidSet in the opposite coordinate system. Open to moving this as a method of AfidSet, but opted for a separate function as a first pass. 

One thing that needs to be checked is if the coordinates need to be in a certain system to work with the affine pulled via nibabel in the world / voxel functions, but that should be done in a separate PR if an update is needed.

**Types of changes**
What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

**Checklist**
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

**Notes**
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
