### PR TITLE
Add git release dependency for pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     secrets:
       BP_PAT: ${{ secrets.BP_PAT_TOKEN }}
   deploy-pypi:
+    needs: [release-package]
     uses: khanlab/actions/.github/workflows/workflow-release_task-deployPypi.yml@v0.3.2
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
**Proposed changes**
The PyPI release action currently runs in parallel with the Github release. This can cause the previous tag to be (incorrectly) used, causing a conflict with trying to push a new release to PyPI. This adds a dependency of the PyPI portion of the workflow to depend on the github release to be first performed.

**Types of changes**
What types of changes does your code introduce? Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

**Checklist**
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

**Notes**
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
